### PR TITLE
EWD compatibility. Double Scaling the locations' positions fix.

### DIFF
--- a/ExpandWorldSize/.gitignore
+++ b/ExpandWorldSize/.gitignore
@@ -1,0 +1,5 @@
+.vs/
+[Bb]in/
+[Oo]bj/
+*.user
+*.suo

--- a/ExpandWorldSize/features/Locations.cs
+++ b/ExpandWorldSize/features/Locations.cs
@@ -24,17 +24,21 @@ public class ModifyLocations
         location.m_quantity = Mathf.RoundToInt(location.m_quantity * Configuration.LocationsMultiplier);
       }
     }
-    if (Configuration.WorldRadius != 10000f)
+
+    //correct the double scaling of location distances when using Expand World Data, as it also scales the world radius and thus the location distances
+    var ewd = BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("expand_world_data");
+    if (!ewd && Configuration.WorldRadius != 10000f)
     {
-      foreach (var location in ZoneSystem.instance.m_locations)
-      {
-        OriginalMin[location] = location.m_minDistance;
-        OriginalMax[location] = location.m_maxDistance;
-        location.m_minDistance *= Configuration.WorldRadius / 10000f;
-        location.m_maxDistance *= Configuration.WorldRadius / 10000f;
-      }
+        foreach (var location in ZoneSystem.instance.m_locations)
+        {
+            OriginalMin[location] = location.m_minDistance;
+            OriginalMax[location] = location.m_maxDistance;
+            location.m_minDistance *= Configuration.WorldRadius / 10000f;
+            location.m_maxDistance *= Configuration.WorldRadius / 10000f;
+        }
     }
-  }
+
+    }
   static void Postfix(bool show)
   {
     if (show) return;


### PR DESCRIPTION
When **Expand World Size (EWS)** and **Expand World Data (EWD)** are used together, a "Double-Scaling" conflict occurs because both mods attempt to be responsible for the same mathematical conversion. 


The gist of what happens:

When the game starts, EWS initializes and sets the world radius to your configured value (e.g., **17,500m**). Through the compatibility shim in `EWD.cs`, EWS informs EWD of this new size via `WorldInfo.Set`. At this point, the entire engine stack agrees the world radius is 17,500m.

Then EWD's `LocationLoading.cs` reads the `expand_locations.yaml`. For a location like Hildir or Elder with a `minDistance` of `0.1`, it calls:
`loc.m_minDistance = WorldEntry.ConvertDist(0.1f);`

Inside `WorldData.cs`, `ConvertDist` performs this math:
`0.1f * WorldInfo.Radius (17500)` = **1,750m**.

Every location in the `ZoneSystem.m_locations` list is now **perfectly scaled** for the whatever size world 17,500 in this example.

Then when world generation begins, the `LoadingIndicator.SetShowProgress` method is called. This triggers the `ModifyLocations.Prefix` inside EWS's `Locations.cs`. 

This code is ensuring locations match the expanded world size, but it is "blind" to the fact that EWD already scaled them. It assumes everything in the list is still at the **Vanilla Scale (10,000m)**.

It executes this loop:
```csharp
foreach (var location in ZoneSystem.instance.m_locations) {
    location.m_minDistance *= Configuration.WorldRadius (17500) / 10000f; // Multiplier is 1.75
}
```
Thus...  It takes the already-scaled **1,750m** and multiplies it by **1.75** again.
**Final Result:** `m_minDistance` = **3,062.5m**.

---

So every location in your game is physically pushed 75% further away from the center than you requested in your YAML. 
*   A location you wanted at **1.7km** (0.1) is now restricted to **3.0km**.
*   A location you wanted at **14km** (0.8) is now restricted to **24.5km**.

My check is in Locations.cs but maybe it should go to EWD.cs in compatibility instead. 