### PR TITLE
LPA integration, fixes, multithread minimap gen

### DIFF
--- a/ExpandWorldSize/ExpandWorldSize.cs
+++ b/ExpandWorldSize/ExpandWorldSize.cs
@@ -13,7 +13,7 @@ public class EWS : BaseUnityPlugin
 {
   public const string GUID = "expand_world_size";
   public const string NAME = "Expand World Size";
-  public const string VERSION = "1.30";
+  public const string VERSION = "1.31";
 #nullable disable
   public static EWS Instance;
 #nullable enable

--- a/ExpandWorldSize/Generate.cs
+++ b/ExpandWorldSize/Generate.cs
@@ -1,4 +1,14 @@
-
+/**
+ * Changes:
+ * - Added LPA detection branch in MapGeneration.Prefix (after the BC branch, so BC wins when both are loaded).
+ * - Fixed PatchTryLoadMinimapTextureData: worldVersion literal bumped 33 -> 37 to match current vanilla. 
+ *   Previously the cache check failed on every saved-world load, forcing a regen every time.
+ *   "public const int m_worldVersion = 37; in dnSpy"
+ * - Parallelized MapGeneration.Generate with Parallel.For using max(1, ProcessorCount - 2) workers.
+ *   Cancellation is now handled with ParallelOptions.CancellationToken
+ * - Dropped the per-pixel Marketplace.IsLoading() wait. The outer coroutine-level wait at the top of Coroutine() already covers the common case (Marketplace still loading when minimap gen begins).
+ */
+using System;
 using System.Collections;
 using System.Diagnostics;
 using System.IO;
@@ -14,19 +24,19 @@ namespace ExpandWorldSize;
 [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.Pregenerate)), HarmonyPriority(Priority.HigherThanNormal)]
 public class Pregenerate
 {
-  static void Prefix(WorldGenerator __instance)
-  {
-    // River points must at least be cleaned.
-    // But better clean up everything.
-    __instance.m_riverCacheLock.EnterWriteLock();
-    __instance.m_riverPoints = [];
-    __instance.m_rivers = [];
-    __instance.m_streams = [];
-    __instance.m_lakes = [];
-    __instance.m_cachedRiverGrid = new(-999999, -999999);
-    __instance.m_cachedRiverPoints = [];
-    __instance.m_riverCacheLock.ExitWriteLock();
-  }
+    static void Prefix(WorldGenerator __instance)
+    {
+        // River points must at least be cleaned.
+        // But better clean up everything.
+        __instance.m_riverCacheLock.EnterWriteLock();
+        __instance.m_riverPoints = [];
+        __instance.m_rivers = [];
+        __instance.m_streams = [];
+        __instance.m_lakes = [];
+        __instance.m_cachedRiverGrid = new(-999999, -999999);
+        __instance.m_cachedRiverPoints = [];
+        __instance.m_riverCacheLock.ExitWriteLock();
+    }
 }
 
 // Cache might have wrong map size so has to be fully reimplemented.
@@ -34,231 +44,249 @@ public class Pregenerate
 [HarmonyPatch(typeof(Minimap), nameof(Minimap.TryLoadMinimapTextureData))]
 public class PatchTryLoadMinimapTextureData
 {
-  static bool Prefix(Minimap __instance, ref bool __result)
-  {
-    __result = TryLoadMinimapTextureData(__instance);
-    return false;
-  }
+    static bool Prefix(Minimap __instance, ref bool __result)
+    {
+        __result = TryLoadMinimapTextureData(__instance);
+        return false;
+    }
 
-  private static bool TryLoadMinimapTextureData(Minimap obj)
-  {
-    if (string.IsNullOrEmpty(obj.m_forestMaskTexturePath) || !File.Exists(obj.m_forestMaskTexturePath) || !File.Exists(obj.m_mapTexturePath) || !File.Exists(obj.m_heightTexturePath) || 33 != ZNet.World.m_worldVersion)
+    private static bool TryLoadMinimapTextureData(Minimap obj)
     {
-      return false;
+        // World version bumped 33 -> 37 to match current vanilla. Vanilla itself
+        // hardcodes the literal in its own TryLoadMinimapTextureData; track that.
+        if (string.IsNullOrEmpty(obj.m_forestMaskTexturePath) || !File.Exists(obj.m_forestMaskTexturePath) || !File.Exists(obj.m_mapTexturePath) || !File.Exists(obj.m_heightTexturePath) || 37 != ZNet.World.m_worldVersion)
+        {
+            return false;
+        }
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        Texture2D texture2D = new Texture2D(obj.m_forestMaskTexture.width, obj.m_forestMaskTexture.height, TextureFormat.ARGB32, false);
+        if (!texture2D.LoadImage(File.ReadAllBytes(obj.m_forestMaskTexturePath)))
+            return false;
+        if (obj.m_forestMaskTexture.width != texture2D.width || obj.m_forestMaskTexture.height != texture2D.height)
+            return false;
+        obj.m_forestMaskTexture.SetPixels(texture2D.GetPixels());
+        obj.m_forestMaskTexture.Apply();
+        if (!texture2D.LoadImage(File.ReadAllBytes(obj.m_mapTexturePath)))
+            return false;
+        if (obj.m_mapTexture.width != texture2D.width || obj.m_mapTexture.height != texture2D.height)
+            return false;
+        obj.m_mapTexture.SetPixels(texture2D.GetPixels());
+        obj.m_mapTexture.Apply();
+        if (!texture2D.LoadImage(File.ReadAllBytes(obj.m_heightTexturePath)))
+            return false;
+        if (obj.m_heightTexture.width != texture2D.width || obj.m_heightTexture.height != texture2D.height)
+            return false;
+        Color[] pixels = texture2D.GetPixels();
+        for (int i = 0; i < obj.m_textureSize; i++)
+        {
+            for (int j = 0; j < obj.m_textureSize; j++)
+            {
+                int num = i * obj.m_textureSize + j;
+                int num2 = (int)(pixels[num].r * 255f);
+                int num3 = (int)(pixels[num].g * 255f);
+                int num4 = (num2 << 8) + num3;
+                float num5 = 127.5f;
+                pixels[num].r = (float)num4 / num5;
+            }
+        }
+        obj.m_heightTexture.SetPixels(pixels);
+        obj.m_heightTexture.Apply();
+        ZLog.Log("Loading minimap textures done [" + stopwatch.ElapsedMilliseconds.ToString() + "ms]");
+        return true;
     }
-    Stopwatch stopwatch = Stopwatch.StartNew();
-    Texture2D texture2D = new Texture2D(obj.m_forestMaskTexture.width, obj.m_forestMaskTexture.height, TextureFormat.ARGB32, false);
-    if (!texture2D.LoadImage(File.ReadAllBytes(obj.m_forestMaskTexturePath)))
-      return false;
-    if (obj.m_forestMaskTexture.width != texture2D.width || obj.m_forestMaskTexture.height != texture2D.height)
-      return false;
-    obj.m_forestMaskTexture.SetPixels(texture2D.GetPixels());
-    obj.m_forestMaskTexture.Apply();
-    if (!texture2D.LoadImage(File.ReadAllBytes(obj.m_mapTexturePath)))
-      return false;
-    if (obj.m_mapTexture.width != texture2D.width || obj.m_mapTexture.height != texture2D.height)
-      return false;
-    obj.m_mapTexture.SetPixels(texture2D.GetPixels());
-    obj.m_mapTexture.Apply();
-    if (!texture2D.LoadImage(File.ReadAllBytes(obj.m_heightTexturePath)))
-      return false;
-    if (obj.m_heightTexture.width != texture2D.width || obj.m_heightTexture.height != texture2D.height)
-      return false;
-    Color[] pixels = texture2D.GetPixels();
-    for (int i = 0; i < obj.m_textureSize; i++)
-    {
-      for (int j = 0; j < obj.m_textureSize; j++)
-      {
-        int num = i * obj.m_textureSize + j;
-        int num2 = (int)(pixels[num].r * 255f);
-        int num3 = (int)(pixels[num].g * 255f);
-        int num4 = (num2 << 8) + num3;
-        float num5 = 127.5f;
-        pixels[num].r = (float)num4 / num5;
-      }
-    }
-    obj.m_heightTexture.SetPixels(pixels);
-    obj.m_heightTexture.Apply();
-    ZLog.Log("Loading minimap textures done [" + stopwatch.ElapsedMilliseconds.ToString() + "ms]");
-    return true;
-  }
 }
 
 [HarmonyPatch(typeof(Minimap), nameof(Minimap.GenerateWorldMap))]
 public class MapGeneration
 {
-  // Some map mods may do stuff after generation which won't work with async.
-  // So do one "fake" generate call to trigger those.
-  static bool DoFakeGenerate = false;
-  static bool Prefix(Minimap __instance)
-  {
-    if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null) return true;
-    if (DoFakeGenerate)
+    // Some map mods may do stuff after generation which won't work with async.
+    // So do one "fake" generate call to trigger those.
+    static bool DoFakeGenerate = false;
+    static bool Prefix(Minimap __instance)
     {
-      DoFakeGenerate = false;
-      return false;
+        if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null) return true;
+        if (DoFakeGenerate)
+        {
+            DoFakeGenerate = false;
+            return false;
+        }
+        /**
+        * Priority: BC > LPA > EWS. BC owns the world if present (its in-game preset switching changes pixel size at runtime, which LPA wont replicate as I was putting that in the better maps mods who knows when I ll do that).
+        * When BC is absent but LPA is present, LPA's parallel implementation supersedes EWS's. When neither is present, EWS does its own (now parallel) gen below.
+        */
+        if (BetterContinents.IsEnabled())
+        {
+            Log.Info($"Better Continents enabled, skipping map generation.");
+            return true;
+        }
+        if (LPACompatibility.IsEnabled())
+        {
+            Log.Info($"Location Placement Accelerator detected, deferring map generation.");
+            return true;
+        }
+        Game.instance.StartCoroutine(Coroutine(__instance));
+        return false;
     }
-    if (BetterContinents.IsEnabled())
+    public static void Cancel()
     {
-      Log.Info($"Better Continents enabled, skipping map generation.");
-      return true;
+        if (CTS != null)
+        {
+            Log.Info($"Cancelling previous map generation.");
+            CTS.Cancel();
+            CTS = null;
+        }
     }
-    Game.instance.StartCoroutine(Coroutine(__instance));
-    return false;
-  }
-  public static void Cancel()
-  {
-    if (CTS != null)
+    public static void UpdateTextureSize(Minimap map, int textureSize)
     {
-      Log.Info($"Cancelling previous map generation.");
-      CTS.Cancel();
-      CTS = null;
+        if (map.m_textureSize == textureSize) return;
+        map.m_textureSize = textureSize;
+        map.m_mapTexture = new(map.m_textureSize, map.m_textureSize, TextureFormat.RGB24, false)
+        {
+            wrapMode = TextureWrapMode.Clamp
+        };
+        map.m_forestMaskTexture = new(map.m_textureSize, map.m_textureSize, TextureFormat.RGBA32, false)
+        {
+            wrapMode = TextureWrapMode.Clamp
+        };
+        map.m_heightTexture = new(map.m_textureSize, map.m_textureSize, TextureFormat.RFloat, false)
+        {
+            wrapMode = TextureWrapMode.Clamp
+        };
+        map.m_fogTexture = new(map.m_textureSize, map.m_textureSize, TextureFormat.RGBA32, false)
+        {
+            wrapMode = TextureWrapMode.Clamp
+        };
+        map.m_explored = new bool[map.m_textureSize * map.m_textureSize];
+        map.m_exploredOthers = new bool[map.m_textureSize * map.m_textureSize];
+        map.m_mapImageLarge.material.SetTexture("_MainTex", map.m_mapTexture);
+        map.m_mapImageLarge.material.SetTexture("_MaskTex", map.m_forestMaskTexture);
+        map.m_mapImageLarge.material.SetTexture("_HeightTex", map.m_heightTexture);
+        map.m_mapImageLarge.material.SetTexture("_FogTex", map.m_fogTexture);
+        map.m_mapImageSmall.material.SetTexture("_MainTex", map.m_mapTexture);
+        map.m_mapImageSmall.material.SetTexture("_MaskTex", map.m_forestMaskTexture);
+        map.m_mapImageSmall.material.SetTexture("_HeightTex", map.m_heightTexture);
+        map.m_mapImageSmall.material.SetTexture("_FogTex", map.m_fogTexture);
+        map.Reset();
     }
-  }
-  public static void UpdateTextureSize(Minimap map, int textureSize)
-  {
-    if (map.m_textureSize == textureSize) return;
-    map.m_textureSize = textureSize;
-    map.m_mapTexture = new(map.m_textureSize, map.m_textureSize, TextureFormat.RGB24, false)
+    public static bool Generating => CTS != null;
+    static CancellationTokenSource? CTS = null;
+    static IEnumerator Coroutine(Minimap map)
     {
-      wrapMode = TextureWrapMode.Clamp
-    };
-    map.m_forestMaskTexture = new(map.m_textureSize, map.m_textureSize, TextureFormat.RGBA32, false)
-    {
-      wrapMode = TextureWrapMode.Clamp
-    };
-    map.m_heightTexture = new(map.m_textureSize, map.m_textureSize, TextureFormat.RFloat, false)
-    {
-      wrapMode = TextureWrapMode.Clamp
-    };
-    map.m_fogTexture = new(map.m_textureSize, map.m_textureSize, TextureFormat.RGBA32, false)
-    {
-      wrapMode = TextureWrapMode.Clamp
-    };
-    map.m_explored = new bool[map.m_textureSize * map.m_textureSize];
-    map.m_exploredOthers = new bool[map.m_textureSize * map.m_textureSize];
-    map.m_mapImageLarge.material.SetTexture("_MainTex", map.m_mapTexture);
-    map.m_mapImageLarge.material.SetTexture("_MaskTex", map.m_forestMaskTexture);
-    map.m_mapImageLarge.material.SetTexture("_HeightTex", map.m_heightTexture);
-    map.m_mapImageLarge.material.SetTexture("_FogTex", map.m_fogTexture);
-    map.m_mapImageSmall.material.SetTexture("_MainTex", map.m_mapTexture);
-    map.m_mapImageSmall.material.SetTexture("_MaskTex", map.m_forestMaskTexture);
-    map.m_mapImageSmall.material.SetTexture("_HeightTex", map.m_heightTexture);
-    map.m_mapImageSmall.material.SetTexture("_FogTex", map.m_fogTexture);
-    map.Reset();
-  }
-  public static bool Generating => CTS != null;
-  static CancellationTokenSource? CTS = null;
-  static IEnumerator Coroutine(Minimap map)
-  {
-    Cancel();
+        Cancel();
 
-    Log.Info($"Starting map generation.");
-    Stopwatch stopwatch = Stopwatch.StartNew();
-    Minimap.DeleteMapTextureData(ZNet.World.m_name);
+        Log.Info($"Starting map generation.");
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        Minimap.DeleteMapTextureData(ZNet.World.m_name);
 
-    int size = map.m_textureSize * map.m_textureSize;
-    var mapTexture = new Color32[size];
-    var forestMaskTexture = new Color32[size];
-    var heightTexture = new Color[size];
-    var cachedTexture = new Color32[size];
+        int size = map.m_textureSize * map.m_textureSize;
+        var mapTexture = new Color32[size];
+        var forestMaskTexture = new Color32[size];
+        var heightTexture = new Color[size];
+        var cachedTexture = new Color32[size];
 
-    CancellationTokenSource cts = new();
-    var ct = cts.Token;
-    while (Marketplace.IsLoading())
-      yield return null;
-    var task = Generate(map, mapTexture, forestMaskTexture, heightTexture, cachedTexture, ct);
-    CTS = cts;
-    while (!task.IsCompleted)
-      yield return null;
+        CancellationTokenSource cts = new();
+        var ct = cts.Token;
+        while (Marketplace.IsLoading())
+            yield return null;
+        var task = Generate(map, mapTexture, forestMaskTexture, heightTexture, cachedTexture, ct);
+        CTS = cts;
+        while (!task.IsCompleted)
+            yield return null;
 
-    if (task.IsFaulted)
-      Log.Error($"Map generation failed!\n{task.Exception}");
-    else if (!ct.IsCancellationRequested)
-    {
-      map.m_mapTexture.SetPixels32(mapTexture);
-      yield return null;
-      map.m_mapTexture.Apply();
-      yield return null;
+        if (task.IsFaulted)
+            Log.Error($"Map generation failed!\n{task.Exception}");
+        else if (!ct.IsCancellationRequested)
+        {
+            map.m_mapTexture.SetPixels32(mapTexture);
+            yield return null;
+            map.m_mapTexture.Apply();
+            yield return null;
 
-      map.m_forestMaskTexture.SetPixels32(forestMaskTexture);
-      yield return null;
-      map.m_forestMaskTexture.Apply();
-      yield return null;
+            map.m_forestMaskTexture.SetPixels32(forestMaskTexture);
+            yield return null;
+            map.m_forestMaskTexture.Apply();
+            yield return null;
 
-      map.m_heightTexture.SetPixels(heightTexture);
-      yield return null;
-      map.m_heightTexture.Apply();
-      yield return null;
-      // Some map mods may do stuff after generation which won't work with async.
-      // So do one "fake" generate call to trigger those.
-      DoFakeGenerate = true;
-      map.GenerateWorldMap();
-      Texture2D cached = new(map.m_textureSize, map.m_textureSize);
-      cached.SetPixels32(cachedTexture);
-      cached.Apply();
-      Log.Info($"Map generation finished ({stopwatch.Elapsed.TotalSeconds:F0} seconds).");
-      map.SaveMapTextureDataToDisk(map.m_forestMaskTexture, map.m_mapTexture, cached);
+            map.m_heightTexture.SetPixels(heightTexture);
+            yield return null;
+            map.m_heightTexture.Apply();
+            yield return null;
+            // Some map mods may do stuff after generation which won't work with async.
+            // So do one "fake" generate call to trigger those.
+            DoFakeGenerate = true;
+            map.GenerateWorldMap();
+            Texture2D cached = new(map.m_textureSize, map.m_textureSize);
+            cached.SetPixels32(cachedTexture);
+            cached.Apply();
+            var workers = Math.Max(1, Environment.ProcessorCount - 2);
+            Log.Info($"Map generation finished ({stopwatch.Elapsed.TotalSeconds:F1}s, parallel, {workers} workers).");
+            map.SaveMapTextureDataToDisk(map.m_forestMaskTexture, map.m_mapTexture, cached);
+        }
+        stopwatch.Stop();
+        cts.Dispose();
+
+        if (CTS == cts)
+            CTS = null;
     }
-    stopwatch.Stop();
-    cts.Dispose();
 
-    if (CTS == cts)
-      CTS = null;
-  }
-
-  static async Task Generate(
-      Minimap map, Color32[] mapTexture, Color32[] forestMaskTexture, Color[] heightTexture, Color32[] cachedtexture, CancellationToken ct)
-  {
-    await Task
-        .Run(
-          () =>
-          {
-            if (ct.IsCancellationRequested)
-              ct.ThrowIfCancellationRequested();
-
-            var wg = WorldGenerator.m_instance;
-            var textureSize = map.m_textureSize; // default 2048
-            var halfTextureSize = textureSize / 2;
-            var pixelSize = map.m_pixelSize;   // default 12
-            var halfPixelSize = pixelSize / 2f;
-            var half = 127.5f;
-
-            for (var i = 0; i < textureSize; i++)
-            {
-              for (var j = 0; j < textureSize; j++)
+    static async Task Generate(
+        Minimap map, Color32[] mapTexture, Color32[] forestMaskTexture, Color[] heightTexture, Color32[] cachedtexture, CancellationToken ct)
+    {
+        await Task
+            .Run(
+              () =>
               {
-                var wx = (j - halfTextureSize) * pixelSize + halfPixelSize;
-                var wy = (i - halfTextureSize) * pixelSize + halfPixelSize;
-                while (Marketplace.IsLoading())
-                {
-                  Log.Info("Waiting 100 ms for Marketplace to load...");
-                  Thread.Sleep(100);
-                }
-                var biome = wg.GetBiome(wx, wy);
-                var biomeHeight = wg.GetBiomeHeight(biome, wx, wy, out var mask);
-                mapTexture[i * textureSize + j] = map.GetPixelColor(biome);
-                forestMaskTexture[i * textureSize + j] = map.GetMaskColor(wx, wy, biomeHeight, biome);
-                heightTexture[i * textureSize + j] = new(biomeHeight, 0f, 0f);
+                  var wg = WorldGenerator.m_instance;
+                  var textureSize = map.m_textureSize; // default 2048
+                  var halfTextureSize = textureSize / 2;
+                  var pixelSize = map.m_pixelSize;   // default 12
+                  var halfPixelSize = pixelSize / 2f;
+                  var half = 127.5f;
 
-                var num = Mathf.Clamp((int)(biomeHeight * half), 0, 65025);
-                var r = (byte)(num >> 8);
-                var g = (byte)(num & 255);
-                cachedtexture[i * textureSize + j] = new(r, g, 0, byte.MaxValue);
-                if (ct.IsCancellationRequested)
-                  ct.ThrowIfCancellationRequested();
-              }
-            }
-          })
-        .ConfigureAwait(continueOnCapturedContext: false);
-  }
+                  // Leave a couple cores free for windowing and the GUI; everyone else is Ben Huring at ramming speed. Same as I did in BC and LPA.
+                  var workers = Math.Max(1, Environment.ProcessorCount - 2);
+                  var pOpts = new ParallelOptions
+                  {
+                      MaxDegreeOfParallelism = workers,
+                      CancellationToken = ct
+                  };
+
+                  try
+                  {
+                      Parallel.For(0, textureSize, pOpts, i =>
+                      {
+                          for (var j = 0; j < textureSize; j++)
+                          {
+                              var wx = (j - halfTextureSize) * pixelSize + halfPixelSize;
+                              var wy = (i - halfTextureSize) * pixelSize + halfPixelSize;
+                              var biome = wg.GetBiome(wx, wy);
+                              var biomeHeight = wg.GetBiomeHeight(biome, wx, wy, out var mask);
+                              mapTexture[i * textureSize + j] = map.GetPixelColor(biome);
+                              forestMaskTexture[i * textureSize + j] = map.GetMaskColor(wx, wy, biomeHeight, biome);
+                              heightTexture[i * textureSize + j] = new(biomeHeight, 0f, 0f);
+
+                              var num = Mathf.Clamp((int)(biomeHeight * half), 0, 65025);
+                              var r = (byte)(num >> 8);
+                              var g = (byte)(num & 255);
+                              cachedtexture[i * textureSize + j] = new(r, g, 0, byte.MaxValue);
+                          }
+                      });
+                  }
+                  catch (OperationCanceledException)
+                  {
+                      // Expected on Game.Logout. The coroutine gates texture upload on
+                      // ct.IsCancellationRequested, so no further action is needed here.
+                  }
+              })
+            .ConfigureAwait(continueOnCapturedContext: false);
+    }
 }
 
 [HarmonyPatch(typeof(Game), nameof(Game.Logout))]
 public class CancelOnLogout
 {
-  static void Prefix()
-  {
-    MapGeneration.Cancel();
-  }
+    static void Prefix()
+    {
+        MapGeneration.Cancel();
+    }
 }

--- a/ExpandWorldSize/Helper.cs
+++ b/ExpandWorldSize/Helper.cs
@@ -1,3 +1,4 @@
+// 0.0.1
 using System.Reflection.Emit;
 using HarmonyLib;
 
@@ -5,31 +6,50 @@ namespace ExpandWorldSize;
 
 public static class Helper
 {
-  public static CodeMatcher Replace(CodeMatcher instructions, double value, double newValue)
-  {
-    return instructions
-      .MatchForward(false, new CodeMatch(OpCodes.Ldc_R8, value))
-      .SetOperandAndAdvance(newValue);
-  }
-  public static CodeMatcher Replace(CodeMatcher instructions, float value, float newValue)
-  {
-    return instructions
-      .MatchForward(false, new CodeMatch(OpCodes.Ldc_R4, value))
-      .SetOperandAndAdvance(newValue);
-  }
+    /**
+     * MatchForward(false, ...) does not throw on miss. It leaves the CodeMatcher
+     * with Pos out of range, and the next call into Operand (or SetOperandAndAdvance,
+     * SetAndAdvance, Advance, RemoveInstruction, etc.) throws
+     * ArgumentOutOfRangeException from _codes[Pos]. That fired whenever a second
+     * transpiler ran on already-mutated IL — i.e. whenever EWS and BC overlapped
+     * on an anchor and BC ran first. The IsInvalid guard turns the hard crash
+     * into a silent no-op, which is the correct semantic: if our anchor is gone,
+     * the first transpiler in the chain already did the work we would have done.
+     */
+    public static CodeMatcher Replace(CodeMatcher instructions, double value, double newValue)
+    {
+        instructions.MatchForward(false, new CodeMatch(OpCodes.Ldc_R8, value));
+        if (instructions.IsInvalid)
+        {
+            return instructions;
+        }
+        return instructions.SetOperandAndAdvance(newValue);
+    }
+    public static CodeMatcher Replace(CodeMatcher instructions, float value, float newValue)
+    {
+        instructions.MatchForward(false, new CodeMatch(OpCodes.Ldc_R4, value));
+        if (instructions.IsInvalid)
+        {
+            return instructions;
+        }
+        return instructions.SetOperandAndAdvance(newValue);
+    }
 
-  public static CodeMatcher ReplaceSeed(CodeMatcher instructions, string name, float value)
-  {
-    return instructions
-      .MatchForward(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(WorldGenerator), name)))
-      .Advance(-1)
-      .SetAndAdvance(OpCodes.Ldc_R4, value)
-      .RemoveInstruction();
-  }
+    public static CodeMatcher ReplaceSeed(CodeMatcher instructions, string name, float value)
+    {
+        instructions.MatchForward(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(WorldGenerator), name)));
+        if (instructions.IsInvalid)
+        {
+            return instructions;
+        }
+        return instructions
+          .Advance(-1)
+          .SetAndAdvance(OpCodes.Ldc_R4, value)
+          .RemoveInstruction();
+    }
 
-  public static float HeightToBaseHeight(float altitude) => altitude / 200f;
-  public static bool IsServer() => ZNet.instance && ZNet.instance.IsServer();
-  // Note: Intended that is client when no Znet instance (so stuff isn't loaded in the main menu).
-  public static bool IsClient() => !IsServer();
+    public static float HeightToBaseHeight(float altitude) => altitude / 200f;
+    public static bool IsServer() => ZNet.instance && ZNet.instance.IsServer();
+    // Note: Intended that is client when no Znet instance (so stuff isn't loaded in the main menu).
+    public static bool IsClient() => !IsServer();
 }
-

--- a/ExpandWorldSize/compatibility/BetterContinents.cs
+++ b/ExpandWorldSize/compatibility/BetterContinents.cs
@@ -2,55 +2,67 @@ using System.Reflection;
 using BepInEx.Bootstrap;
 using HarmonyLib;
 using Service;
-
 namespace ExpandWorldSize;
 
 public class BetterContinents
 {
-  public const string GUID = "BetterContinents";
-  private static Assembly? Assembly;
-  private static FieldInfo? SettingsField;
-  private static FieldInfo? IsEnabledField;
-  private static MethodInfo? SetSizeMethod;
-  private static FieldInfo? WorldSizeField;
-  private static FieldInfo? EdgeSizeField;
-  public static void Run()
-  {
-    if (!Chainloader.PluginInfos.TryGetValue(GUID, out var info)) return;
-    Assembly = info.Instance.GetType().Assembly;
-    var type = Assembly.GetType("BetterContinents.BetterContinents");
-    if (type == null) return;
-    SettingsField = AccessTools.Field(type, "Settings");
-    if (SettingsField == null) return;
-    type = Assembly.GetType("BetterContinents.BetterContinents+BetterContinentsSettings");
-    IsEnabledField = AccessTools.Field(type, "EnabledForThisWorld");
-    if (IsEnabledField == null) return;
-    type = Assembly.GetType("BetterContinents.BetterContinents");
-    if (type == null) return;
-    SetSizeMethod = AccessTools.Method(type, "SetSize");
-    if (SetSizeMethod != null)
-    {
-      Log.Info("\"Better Continents\" detected. Applying compatibility.");
-      return;
-    }
-    WorldSizeField = AccessTools.Field(type, "WorldSize");
-    EdgeSizeField = AccessTools.Field(type, "EdgeSize");
-    if (EdgeSizeField != null && SetSizeMethod != null)
-      Log.Info("Older \"Better Continents\" detected. Applying compatibility.");
-  }
+    public const string GUID = "BetterContinents";
+    private static Assembly? Assembly;
+    private static FieldInfo? SettingsField;
+    private static FieldInfo? IsEnabledField;
+    private static MethodInfo? SetSizeMethod;
+    private static FieldInfo? WorldSizeField;
+    private static FieldInfo? EdgeSizeField;
+    private static MethodInfo? SetStretchMethod;
 
-  public static bool IsEnabled()
-  {
-    if (SettingsField == null) return false;
-    if (IsEnabledField == null) return false;
-    var settings = SettingsField.GetValue(null);
-    if (settings == null) return false;
-    return (bool)IsEnabledField.GetValue(settings);
-  }
-  public static void RefreshSize()
-  {
-    SetSizeMethod?.Invoke(null, [Configuration.WorldRadius, Configuration.WorldEdgeSize]);
-    WorldSizeField?.SetValue(null, Configuration.WorldTotalRadius);
-    EdgeSizeField?.SetValue(null, Configuration.WorldEdgeSize);
-  }
+    public static void Run()
+    {
+        if (!Chainloader.PluginInfos.TryGetValue(GUID, out var info)) return;
+        Assembly = info.Instance.GetType().Assembly;
+        var type = Assembly.GetType("BetterContinents.BetterContinents");
+        if (type == null) return;
+        SettingsField = AccessTools.Field(type, "Settings");
+        if (SettingsField == null) return;
+        type = Assembly.GetType("BetterContinents.BetterContinents+BetterContinentsSettings");
+        IsEnabledField = AccessTools.Field(type, "EnabledForThisWorld");
+        if (IsEnabledField == null) return;
+        type = Assembly.GetType("BetterContinents.BetterContinents");
+        if (type == null) return;
+        SetSizeMethod = AccessTools.Method(type, "SetSize");
+
+        // Get WorldSizeHelper and SetStretch method
+        var worldSizeHelperType = Assembly.GetType("BetterContinents.WorldSizeHelper");
+        if (worldSizeHelperType != null)
+        {
+            SetStretchMethod = AccessTools.Method(worldSizeHelperType, "SetStretch");
+        }
+
+        if (SetSizeMethod != null)
+        {
+            Log.Info("\"Better Continents\" detected. Applying compatibility.");
+            return;
+        }
+        WorldSizeField = AccessTools.Field(type, "WorldSize");
+        EdgeSizeField = AccessTools.Field(type, "EdgeSize");
+        if (EdgeSizeField != null && SetSizeMethod != null)
+            Log.Info("Older \"Better Continents\" detected. Applying compatibility.");
+    }
+
+    public static bool IsEnabled()
+    {
+        if (SettingsField == null) return false;
+        if (IsEnabledField == null) return false;
+        var settings = SettingsField.GetValue(null);
+        if (settings == null) return false;
+        return (bool)IsEnabledField.GetValue(settings);
+    }
+
+    public static void RefreshSize()
+    {
+        SetSizeMethod?.Invoke(null, [Configuration.WorldRadius, Configuration.WorldEdgeSize]);
+        WorldSizeField?.SetValue(null, Configuration.WorldTotalRadius);
+        EdgeSizeField?.SetValue(null, Configuration.WorldEdgeSize);
+        // Pass EWS's stretch values to BC's WorldSizeHelper
+        SetStretchMethod?.Invoke(null, [Configuration.WorldStretch, Configuration.BiomeStretch]);
+    }
 }

--- a/ExpandWorldSize/compatibility/LPACompatibility.cs
+++ b/ExpandWorldSize/compatibility/LPACompatibility.cs
@@ -1,0 +1,40 @@
+﻿// v0.0.1
+using BepInEx.Bootstrap;
+using Service;
+
+namespace ExpandWorldSize;
+
+/**
+ * Detects Location Placement Accelerator (LPA). When LPA is loaded, EWS
+ * defers minimap generation to LPA's parallel implementation, which uses
+ * Environment.ProcessorCount - 2 workers vs EWS's single thread.
+ *
+ * LPA reads m_textureSize and m_pixelSize directly from the Minimap instance at generation time. 
+ * EWS's MinimapAwake.Postfix has already mutated those instance fields from Configuration.MapSize
+ * and Configuration.MapPixelSize before any generation runs, so the EWS pixel-size and texture-size settings are honored regardless of who
+ * performs the gen. All good here.
+ *
+ * Priority when both BC and LPA are present: BC wins because that is how I had designed LPA initially. BC takes full ownership 
+ * of the world (including a custom pixel-size flow tied to its in-game preset switching), and LPA itself defers to BC. EWS therefore checks BC
+ * first and LPA second. 
+ *
+ * Detection is lazy on first call to IsEnabled() so this file is drop-in without requiring any change to ExpandWorldSize.cs.
+ */
+public class LPACompatibility
+{
+    public const string GUID = "nickpappas.locationplacementaccelerator";
+    private static bool _checked;
+    private static bool _present;
+
+    public static bool IsEnabled()
+    {
+        if (!_checked)
+        {
+            _checked = true;
+            _present = Chainloader.PluginInfos.ContainsKey(GUID);
+            if (_present)
+                Log.Info("\"Location Placement Accelerator\" detected. Deferring minimap generation to LPA.");
+        }
+        return _present;
+    }
+}

--- a/ExpandWorldSize/features/Stretch.cs
+++ b/ExpandWorldSize/features/Stretch.cs
@@ -1,3 +1,4 @@
+// 0.0.1
 using System.Collections.Generic;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -9,158 +10,174 @@ namespace ExpandWorldSize;
 [HarmonyPatch]
 public class Stretch
 {
-  public static IEnumerable<CodeInstruction> StretchIsAshlandsTranspiler(IEnumerable<CodeInstruction> instructions)
-  {
-    return new CodeMatcher(instructions)
-      .MatchForward(false, new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(WorldGenerator), nameof(WorldGenerator.IsAshlands))))
-      .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.z))))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
-      .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.x))))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
-      .InstructionEnumeration();
-  }
-  public static IEnumerable<CodeInstruction> StretchIsAshlandsDeepNorthTranspiler(IEnumerable<CodeInstruction> instructions)
-  {
-    return new CodeMatcher(instructions)
-      .MatchForward(false, new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(WorldGenerator), nameof(WorldGenerator.IsAshlands))))
-      .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.z))))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
-      .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.x))))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
-      .MatchForward(false, new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(WorldGenerator), nameof(WorldGenerator.IsDeepnorth))))
-      .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.z))))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
-      .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.x))))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
-      .InstructionEnumeration();
-  }
-  [HarmonyPriority(Priority.HigherThanNormal)]
-  public static void StretchVector3(ref Vector3 pos)
-  {
-    pos = pos with { x = pos.x / Configuration.WorldStretch, z = pos.z / Configuration.WorldStretch };
-  }
-  [HarmonyPriority(Priority.HigherThanNormal)]
-  public static void GetMaskColor(ref float wx, ref float wy)
-  {
-    wx /= Configuration.WorldStretch;
-    wy /= Configuration.WorldStretch;
-  }
-  [HarmonyPriority(Priority.HigherThanNormal)]
-  public static void GetBiomeHeight(ref float wx, ref float wy)
-  {
-    wx /= Configuration.WorldStretch;
-    wy /= Configuration.WorldStretch;
-  }
-  [HarmonyPriority(Priority.HigherThanNormal)]
-  public static void GetBiome(ref float wx, ref float wy)
-  {
-    // Stretch should "slow down" both GetBaseHeight and PerlinNoise.
-    // So this is the easiest way to do it.
-    // Alternatively could transpile each usage.
-    wx /= Configuration.WorldStretch;
-    wy /= Configuration.WorldStretch;
-  }
+    public static IEnumerable<CodeInstruction> StretchIsAshlandsTranspiler(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions)
+          .MatchForward(false, new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(WorldGenerator), nameof(WorldGenerator.IsAshlands))))
+          .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.z))))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
+          .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.x))))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
+          .InstructionEnumeration();
+    }
+    public static IEnumerable<CodeInstruction> StretchIsAshlandsDeepNorthTranspiler(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions)
+          .MatchForward(false, new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(WorldGenerator), nameof(WorldGenerator.IsAshlands))))
+          .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.z))))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
+          .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.x))))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
+          .MatchForward(false, new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(WorldGenerator), nameof(WorldGenerator.IsDeepnorth))))
+          .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.z))))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
+          .MatchBack(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Vector3), nameof(Vector3.x))))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
+          .InstructionEnumeration();
+    }
+    [HarmonyPriority(Priority.HigherThanNormal)]
+    public static void StretchVector3(ref Vector3 pos)
+    {
+        pos = pos with { x = pos.x / Configuration.WorldStretch, z = pos.z / Configuration.WorldStretch };
+    }
+    [HarmonyPriority(Priority.HigherThanNormal)]
+    public static void GetMaskColor(ref float wx, ref float wy)
+    {
+        wx /= Configuration.WorldStretch;
+        wy /= Configuration.WorldStretch;
+    }
+    [HarmonyPriority(Priority.HigherThanNormal)]
+    public static void GetBiomeHeight(ref float wx, ref float wy)
+    {
+        wx /= Configuration.WorldStretch;
+        wy /= Configuration.WorldStretch;
+    }
+    [HarmonyPriority(Priority.HigherThanNormal)]
+    public static void GetBiome(ref float wx, ref float wy)
+    {
+        // Stretch should "slow down" both GetBaseHeight and PerlinNoise.
+        // So this is the easiest way to do it.
+        // Alternatively could transpile each usage.
+        wx /= Configuration.WorldStretch;
+        wy /= Configuration.WorldStretch;
+    }
 
-  public static CodeMatcher Replace(CodeMatcher matcher, OpCode code)
-  {
-    if (Configuration.WorldStretch == 1f) return matcher;
-    return matcher
-      .MatchForward(false, new CodeMatch(code))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div));
-  }
-  public static CodeMatcher ReplaceBiome(CodeMatcher matcher)
-  {
-    if (Configuration.BiomeStretch == 1f) return matcher;
-    return matcher
-      .MatchForward(false, new(OpCodes.Ldarg_1), new(OpCodes.Conv_R8), new(OpCodes.Add))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.BiomeStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
-      .MatchForward(false, new(OpCodes.Ldarg_2), new(OpCodes.Conv_R8), new(OpCodes.Add))
-      .Advance(1)
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.BiomeStretch))
-      .InsertAndAdvance(new CodeInstruction(OpCodes.Div));
-  }
+    public static CodeMatcher Replace(CodeMatcher matcher, OpCode code)
+    {
+        if (Configuration.WorldStretch == 1f) return matcher;
+        return matcher
+          .MatchForward(false, new CodeMatch(code))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.WorldStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div));
+    }
+    public static CodeMatcher ReplaceBiome(CodeMatcher matcher)
+    {
+        if (Configuration.BiomeStretch == 1f) return matcher;
+        return matcher
+          .MatchForward(false, new(OpCodes.Ldarg_1), new(OpCodes.Conv_R8), new(OpCodes.Add))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.BiomeStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div))
+          .MatchForward(false, new(OpCodes.Ldarg_2), new(OpCodes.Conv_R8), new(OpCodes.Add))
+          .Advance(1)
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_R4, Configuration.BiomeStretch))
+          .InsertAndAdvance(new CodeInstruction(OpCodes.Div));
+    }
 
-  [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.GetBiome), typeof(float), typeof(float), typeof(float), typeof(bool))]
+    [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.GetBiome), typeof(float), typeof(float), typeof(float), typeof(bool))]
 
-  static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-  {
-    if (Patcher.IsMenu) return instructions;
-    CodeMatcher matcher = new(instructions);
-    matcher = ReplaceBiome(matcher);
-    matcher = ReplaceBiome(matcher);
-    matcher = ReplaceBiome(matcher);
-    matcher = ReplaceBiome(matcher);
-    matcher = new(matcher.InstructionEnumeration());
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        if (Patcher.IsMenu) return instructions;
+        CodeMatcher matcher = new(instructions);
+        matcher = ReplaceBiome(matcher);
+        matcher = ReplaceBiome(matcher);
+        matcher = ReplaceBiome(matcher);
+        matcher = ReplaceBiome(matcher);
+        matcher = new(matcher.InstructionEnumeration());
 
-    var field = AccessTools.Field(typeof(WorldGenerator), nameof(WorldGenerator.ashlandsMinDistance));
-    field.SetValue(null, 1.2f * Configuration.StrechedWorldRadius);
-    field = AccessTools.Field(typeof(WorldGenerator), nameof(WorldGenerator.ashlandsYOffset));
-    field.SetValue(null, -0.4f * Configuration.StrechedWorldRadius);
+        var field = AccessTools.Field(typeof(WorldGenerator), nameof(WorldGenerator.ashlandsMinDistance));
+        field.SetValue(null, 1.2f * Configuration.StrechedWorldRadius);
+        field = AccessTools.Field(typeof(WorldGenerator), nameof(WorldGenerator.ashlandsYOffset));
+        field.SetValue(null, -0.4f * Configuration.StrechedWorldRadius);
 
-    matcher = Helper.Replace(matcher, 2000f, 0.2f * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 6000d, 0.6 * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 10000f, Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 3000d, 0.3 * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 8000f, 0.8f * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 600d, 0.06 * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 6000f, 0.6f * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 5000d, 0.5 * Configuration.StrechedWorldRadius);
-    return matcher.InstructionEnumeration();
-  }
+        matcher = Helper.Replace(matcher, 2000f, 0.2f * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 6000d, 0.6 * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 10000f, Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 3000d, 0.3 * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 8000f, 0.8f * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 600d, 0.06 * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 6000f, 0.6f * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 5000d, 0.5 * Configuration.StrechedWorldRadius);
+        return matcher.InstructionEnumeration();
+    }
 
 
-  [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.IsDeepnorth)), HarmonyTranspiler]
+    [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.IsDeepnorth)), HarmonyTranspiler]
 
-  static IEnumerable<CodeInstruction> TranspilerIsDeepnorth(IEnumerable<CodeInstruction> instructions)
-  {
-    if (Patcher.IsMenu) return instructions;
-    CodeMatcher matcher = new(instructions);
-    matcher = Helper.Replace(matcher, 4000d, 0.4 * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 12000d, 1.2 * Configuration.StrechedWorldRadius);
-    return matcher.InstructionEnumeration();
-  }
+    static IEnumerable<CodeInstruction> TranspilerIsDeepnorth(IEnumerable<CodeInstruction> instructions)
+    {
+        if (Patcher.IsMenu) return instructions;
+        CodeMatcher matcher = new(instructions);
+        matcher = Helper.Replace(matcher, 4000d, 0.4 * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 12000d, 1.2 * Configuration.StrechedWorldRadius);
+        return matcher.InstructionEnumeration();
+    }
 
-  [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.CreateAshlandsGap)), HarmonyTranspiler]
-  static IEnumerable<CodeInstruction> TranspilerCreateAshlandsGap(IEnumerable<CodeInstruction> instructions)
-  {
-    if (Patcher.IsMenu) return instructions;
-    CodeMatcher matcher = new(instructions);
-    matcher = Helper.Replace(matcher, 400d, 0.04 * Configuration.StrechedWorldRadius);
-    return matcher.InstructionEnumeration();
-  }
+    [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.CreateAshlandsGap)), HarmonyTranspiler]
+    static IEnumerable<CodeInstruction> TranspilerCreateAshlandsGap(IEnumerable<CodeInstruction> instructions)
+    {
+        if (Patcher.IsMenu) return instructions;
+        CodeMatcher matcher = new(instructions);
+        matcher = Helper.Replace(matcher, 400d, 0.04 * Configuration.StrechedWorldRadius);
+        return matcher.InstructionEnumeration();
+    }
 
-  [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.CreateDeepNorthGap)), HarmonyTranspiler]
-  static IEnumerable<CodeInstruction> TranspilerCreateDeepNorthGap(IEnumerable<CodeInstruction> instructions)
-  {
-    if (Patcher.IsMenu) return instructions;
-    CodeMatcher matcher = new(instructions);
-    matcher = Helper.Replace(matcher, 4000f, 0.4f * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 12000d, 1.2f * Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 400d, 0.04 * Configuration.StrechedWorldRadius);
-    return matcher.InstructionEnumeration();
-  }
-  [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.GetBiomeHeight)), HarmonyTranspiler]
-  static IEnumerable<CodeInstruction> TranspilerGetBiomeHeight(IEnumerable<CodeInstruction> instructions)
-  {
-    if (Patcher.IsMenu) return instructions;
-    CodeMatcher matcher = new(instructions);
-    matcher = Helper.Replace(matcher, 10500f, Configuration.StrechedWorldTotalRadius);
-    return matcher.InstructionEnumeration();
-  }
+    [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.CreateDeepNorthGap)), HarmonyTranspiler]
+    static IEnumerable<CodeInstruction> TranspilerCreateDeepNorthGap(IEnumerable<CodeInstruction> instructions)
+    {
+        if (Patcher.IsMenu) return instructions;
+        CodeMatcher matcher = new(instructions);
+        matcher = Helper.Replace(matcher, 4000f, 0.4f * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 12000d, 1.2f * Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 400d, 0.04 * Configuration.StrechedWorldRadius);
+        return matcher.InstructionEnumeration();
+    }
+    [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.GetBiomeHeight)), HarmonyTranspiler]
+    static IEnumerable<CodeInstruction> TranspilerGetBiomeHeight(IEnumerable<CodeInstruction> instructions)
+    {
+        /**
+         * Same conflict as EnvMan.UpdateWind: BC's WorldSizeHelper.PatchBiomeHeight
+         * installs ReplaceTotalSize on this same method against the same 10500f
+         * anchor. When BC has already patched (it patches at world load, this fires
+         * during WorldGenerator..ctor which is later), Harmony rebuilds the wrapper
+         * with both transpilers chained; the BC-mutated IL no longer contains the
+         * 10500f anchor and Helper.Replace crashes (no IsInvalid guard, Pos goes
+         * out of range, Operand getter throws). BC owns runtime size-derived
+         * patches when present; EWS's size config already reaches BC through the
+         * SetSize shim so BC's transpiler runs with the right numbers.
+         */
+        if (BetterContinents.IsEnabled())
+        {
+            return instructions;
+        }
+
+        if (Patcher.IsMenu) return instructions;
+        CodeMatcher matcher = new(instructions);
+        matcher = Helper.Replace(matcher, 10500f, Configuration.StrechedWorldTotalRadius);
+        return matcher.InstructionEnumeration();
+    }
 }

--- a/ExpandWorldSize/features/WorldSize.cs
+++ b/ExpandWorldSize/features/WorldSize.cs
@@ -1,3 +1,4 @@
+// 0.0.2
 using System.Collections.Generic;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -6,132 +7,165 @@ namespace ExpandWorldSize;
 
 public class WorldSizeHelper
 {
-  public static IEnumerable<CodeInstruction> EdgeCheck(IEnumerable<CodeInstruction> instructions)
-  {
-    CodeMatcher matcher = new(instructions);
-    matcher = Helper.Replace(matcher, 10420f, Configuration.WorldTotalRadius - 80);
-    matcher = Helper.Replace(matcher, 10500f, Configuration.WorldTotalRadius);
-    return matcher.InstructionEnumeration();
-  }
+    public static IEnumerable<CodeInstruction> EdgeCheck(IEnumerable<CodeInstruction> instructions)
+    {
+        // BC owns size-derived IL patches when present; EWS already fed it the radius via SetSize.
+        if (BetterContinents.IsEnabled())
+        {
+            return instructions;
+        }
+        CodeMatcher matcher = new(instructions);
+        matcher = Helper.Replace(matcher, 10420f, Configuration.WorldTotalRadius - 80);
+        matcher = Helper.Replace(matcher, 10500f, Configuration.WorldTotalRadius);
+        return matcher.InstructionEnumeration();
+    }
 }
 
 [HarmonyPatch(typeof(Ship), nameof(Ship.ApplyEdgeForce))]
 public class ApplyEdgeForce
 {
-  static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions) => WorldSizeHelper.EdgeCheck(instructions);
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions) => WorldSizeHelper.EdgeCheck(instructions);
 }
 
 [HarmonyPatch(typeof(Player), nameof(Player.EdgeOfWorldKill))]
 public class EdgeOfWorldKill
 {
-  static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions) => WorldSizeHelper.EdgeCheck(instructions);
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions) => WorldSizeHelper.EdgeCheck(instructions);
 
-  // Safer to simply skip when in dungeons.
-  static bool Prefix(Player __instance) => __instance.transform.position.y < 4000f;
+    // Safer to simply skip when in dungeons.
+    static bool Prefix(Player __instance) => __instance.transform.position.y < 4000f;
 }
 
 [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.GetAshlandsHeight))]
 public class GetAshlandsHeightSize
 {
-  static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-  {
-    if (Patcher.IsMenu) return instructions;
-    CodeMatcher matcher = new(instructions);
-    // Incoming coordinates are stretched, so all limits must be stretched as well.
-    matcher = Helper.Replace(matcher, 10150d, (Configuration.WorldTotalRadius + 150f) / Configuration.WorldStretch);
-    return matcher.InstructionEnumeration();
-  }
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        // BC owns size-derived IL patches when present; EWS already fed it the radius via SetSize.
+        if (BetterContinents.IsEnabled())
+        {
+            return instructions;
+        }
+        if (Patcher.IsMenu) return instructions;
+        CodeMatcher matcher = new(instructions);
+        // Incoming coordinates are stretched, so all limits must be stretched as well.
+        matcher = Helper.Replace(matcher, 10150d, (Configuration.WorldTotalRadius + 150f) / Configuration.WorldStretch);
+        return matcher.InstructionEnumeration();
+    }
 }
 
 [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.GetBaseHeight))]
 public class GetBaseHeight
 {
-  static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-  {
-    if (Patcher.IsMenu) return instructions;
-    CodeMatcher matcher = new(instructions);
-    // Skipping the menu part.
-    matcher = matcher.MatchForward(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(WorldGenerator), nameof(WorldGenerator.m_offset1))));
-    if (Configuration.OffsetX != null)
-      matcher = Helper.ReplaceSeed(matcher, nameof(WorldGenerator.m_offset0), Configuration.OffsetX.Value);
-    if (Configuration.OffsetY != null)
-      matcher = Helper.ReplaceSeed(matcher, nameof(WorldGenerator.m_offset1), Configuration.OffsetY.Value);
-    // Incoming coordinates are stretched, so all limits must be stretched as well.
-    matcher = Helper.Replace(matcher, 10000f, Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 10000f, Configuration.StrechedWorldRadius);
-    matcher = Helper.Replace(matcher, 10500f, Configuration.StrechedWorldTotalRadius);
-    matcher = Helper.Replace(matcher, 10490f, (Configuration.WorldTotalRadius - 10f) / Configuration.WorldStretch);
-    matcher = Helper.Replace(matcher, 10500f, Configuration.StrechedWorldTotalRadius);
-    return matcher.InstructionEnumeration();
-  }
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        // BC owns size-derived IL patches when present; EWS already fed it the radius via SetSize.
+        if (BetterContinents.IsEnabled())
+        {
+            return instructions;
+        }
+        if (Patcher.IsMenu) return instructions;
+        CodeMatcher matcher = new(instructions);
+        // Skipping the menu part.
+        matcher = matcher.MatchForward(false, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(WorldGenerator), nameof(WorldGenerator.m_offset1))));
+        if (Configuration.OffsetX != null)
+            matcher = Helper.ReplaceSeed(matcher, nameof(WorldGenerator.m_offset0), Configuration.OffsetX.Value);
+        if (Configuration.OffsetY != null)
+            matcher = Helper.ReplaceSeed(matcher, nameof(WorldGenerator.m_offset1), Configuration.OffsetY.Value);
+        // Incoming coordinates are stretched, so all limits must be stretched as well.
+        matcher = Helper.Replace(matcher, 10000f, Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 10000f, Configuration.StrechedWorldRadius);
+        matcher = Helper.Replace(matcher, 10500f, Configuration.StrechedWorldTotalRadius);
+        matcher = Helper.Replace(matcher, 10490f, (Configuration.WorldTotalRadius - 10f) / Configuration.WorldStretch);
+        matcher = Helper.Replace(matcher, 10500f, Configuration.StrechedWorldTotalRadius);
+        return matcher.InstructionEnumeration();
+    }
 }
 
 [HarmonyPatch(typeof(WaterVolume), nameof(WaterVolume.SetupMaterial))]
 public class SetupMaterial
 {
-  public static void Refresh()
-  {
-    foreach (var water in WaterVolume.Instances)
-      water.m_waterSurface.sharedMaterial.SetFloat("_WaterEdge", Configuration.WorldTotalRadius);
-  }
-  public static void Prefix(WaterVolume __instance)
-  {
-    __instance.m_waterSurface.sharedMaterial.SetFloat("_WaterEdge", Configuration.WorldTotalRadius);
-    // Zone water should be at y 30, anything above that is dungeon water and anything below is end of the world.
-    if (__instance.transform.position.y < 30.001f && __instance.transform.position.y > 29.999f && __instance.m_collider is BoxCollider box)
+    public static void Refresh()
     {
-      // Default is -20 center with 60 size, probably 10 meters extra for waves.
-      // -100 meters should give plenty of space for deeper water.
-      box.center = new Vector3(0, -100, 0);
-      box.size = new Vector3(64, 220, 64);
+        foreach (var water in WaterVolume.Instances)
+            water.m_waterSurface.sharedMaterial.SetFloat("_WaterEdge", Configuration.WorldTotalRadius);
     }
-    WaterColor.FixColors(__instance.m_waterSurface.sharedMaterial);
-  }
+    public static void Prefix(WaterVolume __instance)
+    {
+        __instance.m_waterSurface.sharedMaterial.SetFloat("_WaterEdge", Configuration.WorldTotalRadius);
+        // Zone water should be at y 30, anything above that is dungeon water and anything below is end of the world.
+        if (__instance.transform.position.y < 30.001f && __instance.transform.position.y > 29.999f && __instance.m_collider is BoxCollider box)
+        {
+            // Default is -20 center with 60 size, probably 10 meters extra for waves.
+            // -100 meters should give plenty of space for deeper water.
+            box.center = new Vector3(0, -100, 0);
+            box.size = new Vector3(64, 220, 64);
+        }
+        WaterColor.FixColors(__instance.m_waterSurface.sharedMaterial);
+    }
 }
 
 [HarmonyPatch(typeof(EnvMan), nameof(EnvMan.Awake))]
 public class ScaleGlobalWaterSurface
 {
-  public static void Refresh(EnvMan obj)
-  {
-    var water = obj.transform.Find("WaterPlane").Find("watersurface");
-    if (!water) return;
-    var mat = water.GetComponent<MeshRenderer>().sharedMaterial;
-    mat.SetFloat("_WaterEdge", Configuration.WorldTotalRadius);
-  }
-  public static void Postfix(EnvMan __instance) => Refresh(__instance);
+    public static void Refresh(EnvMan obj)
+    {
+        var water = obj.transform.Find("WaterPlane").Find("watersurface");
+        if (!water) return;
+        var mat = water.GetComponent<MeshRenderer>().sharedMaterial;
+        mat.SetFloat("_WaterEdge", Configuration.WorldTotalRadius);
+    }
+    public static void Postfix(EnvMan __instance) => Refresh(__instance);
 }
 
 [HarmonyPatch(typeof(EnvMan), nameof(EnvMan.UpdateWind))]
 public class UpdateWind
 {
-  static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-  {
-    CodeMatcher matcher = new(instructions);
-    matcher = Helper.Replace(matcher, 10500f, Configuration.WorldRadius);
-    // Removes the subtraction of m_edgeOfWorldWidth (already applied above).
-    matcher = matcher
-      .SetOpcodeAndAdvance(OpCodes.Nop)
-      .SetOpcodeAndAdvance(OpCodes.Nop)
-      .SetOpcodeAndAdvance(OpCodes.Nop);
-    matcher = Helper.Replace(matcher, 10500f, Configuration.WorldRadius);
-    // Removes the subtraction of m_edgeOfWorldWidth (already applied above).
-    matcher = matcher
-      .SetOpcodeAndAdvance(OpCodes.Nop)
-      .SetOpcodeAndAdvance(OpCodes.Nop)
-      .SetOpcodeAndAdvance(OpCodes.Nop);
-    matcher = Helper.Replace(matcher, 10500f, Configuration.WorldTotalRadius);
-    return matcher.InstructionEnumeration();
-  }
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        /**
+         * BC owns runtime size-derived game-system patches when present. Both mods
+         * implement the same Replace+3xNOP pattern against the same anchors here,
+         * and whichever transpiler runs second cannot find its 10500f anchor (the
+         * first already mutated it). Helper.Replace is now guarded against the
+         * out-of-range crash, but we still defer when BC is active so BC's math
+         * wins cleanly without two mods racing to mutate the same IL.
+         */
+        if (BetterContinents.IsEnabled())
+        {
+            return instructions;
+        }
+
+        CodeMatcher matcher = new(instructions);
+        matcher = Helper.Replace(matcher, 10500f, Configuration.WorldRadius);
+        // Removes the subtraction of m_edgeOfWorldWidth (already applied above).
+        matcher = matcher
+          .SetOpcodeAndAdvance(OpCodes.Nop)
+          .SetOpcodeAndAdvance(OpCodes.Nop)
+          .SetOpcodeAndAdvance(OpCodes.Nop);
+        matcher = Helper.Replace(matcher, 10500f, Configuration.WorldRadius);
+        // Removes the subtraction of m_edgeOfWorldWidth (already applied above).
+        matcher = matcher
+          .SetOpcodeAndAdvance(OpCodes.Nop)
+          .SetOpcodeAndAdvance(OpCodes.Nop)
+          .SetOpcodeAndAdvance(OpCodes.Nop);
+        matcher = Helper.Replace(matcher, 10500f, Configuration.WorldTotalRadius);
+        return matcher.InstructionEnumeration();
+    }
 }
 
 [HarmonyPatch(typeof(WaterVolume), nameof(WaterVolume.GetWaterSurface))]
 public class GetWaterSurface
 {
-  static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-  {
-    CodeMatcher matcher = new(instructions);
-    matcher = Helper.Replace(matcher, 10500f, Configuration.WorldTotalRadius);
-    return matcher.InstructionEnumeration();
-  }
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        // BC owns size-derived IL patches when present; EWS already fed it the radius via SetSize.
+        if (BetterContinents.IsEnabled())
+        {
+            return instructions;
+        }
+        CodeMatcher matcher = new(instructions);
+        matcher = Helper.Replace(matcher, 10500f, Configuration.WorldTotalRadius);
+        return matcher.InstructionEnumeration();
+    }
 }


### PR DESCRIPTION
Various fixes some from back in February. Merged with 1.3. 
New stuff, LPA integration. 
Order is like so:
EWS detects no BC or LPA, does the minimap on its own but multithreaded like I do in LPA and BC (available cores - 2) so on a 10k world it is instant, on a 20k for me is about 6secs or so. 

If BC or LPA are detected then EWS sends the minimap to them. BC if both BC and LPA are there, LPA otherwise. 

All three now generate the minimap at the same speed (and LPA could potentially use the minimap info to improve the survey further in the future. )
